### PR TITLE
OpenAPI documentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,6 +39,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -123,6 +132,8 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+ "utoipa",
+ "utoipa-swagger-ui",
  "uuid",
 ]
 
@@ -480,6 +491,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -607,6 +629,7 @@ checksum = "b375d6465b98090a5f25b1c7703f3859783755aa9a80433b36e0379a3ec2f369"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -1157,6 +1180,8 @@ checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1660,6 +1685,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f3fe0889e69e2ae9e41f4d6c4c0181701d00e4697b356fb1f74173a5e0ee27"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -2835,6 +2872,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
+name = "utoipa"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fcc29c80c21c31608227e0912b2d7fddba57ad76b606890627ba8ee7964e993"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_json",
+ "utoipa-gen",
+]
+
+[[package]]
+name = "utoipa-gen"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d79d08d92ab8af4c5e8a6da20c47ae3f61a0f1dabc1997cdf2d082b757ca08b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn",
+ "uuid",
+]
+
+[[package]]
+name = "utoipa-swagger-ui"
+version = "9.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d047458f1b5b65237c2f6dc6db136945667f40a7668627b3490b9513a3d43a55"
+dependencies = [
+ "axum",
+ "base64 0.22.1",
+ "mime_guess",
+ "regex",
+ "rust-embed",
+ "serde",
+ "serde_json",
+ "url",
+ "utoipa",
+ "zip",
+]
+
+[[package]]
 name = "uuid"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3413,7 +3493,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12598812502ed0105f607f941c386f43d441e00148fce9dec3ca5ffb0bde9308"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "zopfli",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40990edd51aae2c2b6907af74ffb635029d5788228222c4bb811e9351c0caad3"
+
+[[package]]
 name = "zmij"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfcd145825aace48cff44a8844de64bf75feec3080e0aa5cdbde72961ae51a65"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,3 +37,5 @@ futures = "0.3.31"
 reqwest = { version = "0.12", features = ["json"] }
 rust_socketio = { version = "0.6", features = ["async"] }
 url = "2"
+utoipa = { version = "5.3", features = ["axum_extras", "chrono", "uuid"] }
+utoipa-swagger-ui = { version = "9.0", features = ["axum"] }

--- a/src/api/dashboard.rs
+++ b/src/api/dashboard.rs
@@ -1,12 +1,21 @@
 use axum::{Json, Router, extract::State, routing::get};
 
-use crate::service::dashboard;
+use crate::service::dashboard::{self, DashboardStats};
 use crate::{AppState, Result};
 
 pub fn routes() -> Router<AppState> {
     Router::new().route("/stats", get(stats))
 }
 
+#[utoipa::path(
+    get,
+    path = "/api/dashboard/stats",
+    tag = "dashboard",
+    responses(
+        (status = 200, description = "Dashboard statistics", body = DashboardStats),
+        (status = 500, description = "Internal server error")
+    )
+)]
 async fn stats(State(state): State<AppState>) -> Result<impl axum::response::IntoResponse> {
     let result = dashboard::get_stats(&state.pool).await?;
     Ok(Json(result))

--- a/src/api/domains.rs
+++ b/src/api/domains.rs
@@ -5,7 +5,7 @@ use axum::{
 };
 use serde::Deserialize;
 
-use crate::models::{CreateDomain, PaginationParams, UpdateDomain};
+use crate::models::{CreateDomain, PaginationParams, UpdateDomain, DomainWithRelations, Domain};
 use crate::service::domain;
 use crate::{AppState, Result};
 
@@ -22,6 +22,20 @@ pub fn routes() -> Router<AppState> {
         .route("/{id}", get(get_one).put(update).delete(delete_one))
 }
 
+#[utoipa::path(
+    get,
+    path = "/api/domains",
+    tag = "domains",
+    params(
+        ("page" = Option<u32>, Query, description = "Page number"),
+        ("per_page" = Option<u32>, Query, description = "Items per page (max 100)"),
+        ("search" = Option<String>, Query, description = "Search query"),
+    ),
+    responses(
+        (status = 200, description = "List of domains", body = inline(crate::models::PaginatedResponse<DomainWithRelations>)),
+        (status = 500, description = "Internal server error")
+    )
+)]
 async fn list(
     State(state): State<AppState>,
     Query(filters): Query<DomainFilters>,
@@ -35,6 +49,19 @@ async fn list(
     Ok(Json(result))
 }
 
+#[utoipa::path(
+    get,
+    path = "/api/domains/{id}",
+    tag = "domains",
+    params(
+        ("id" = String, Path, description = "Domain ID")
+    ),
+    responses(
+        (status = 200, description = "Domain found", body = DomainWithRelations),
+        (status = 404, description = "Domain not found"),
+        (status = 500, description = "Internal server error")
+    )
+)]
 async fn get_one(
     State(state): State<AppState>,
     Path(id): Path<String>,
@@ -43,6 +70,17 @@ async fn get_one(
     Ok(Json(result))
 }
 
+#[utoipa::path(
+    post,
+    path = "/api/domains",
+    tag = "domains",
+    request_body = CreateDomain,
+    responses(
+        (status = 201, description = "Domain created", body = Domain),
+        (status = 400, description = "Invalid input"),
+        (status = 500, description = "Internal server error")
+    )
+)]
 async fn create(
     State(state): State<AppState>,
     Json(input): Json<CreateDomain>,
@@ -51,6 +89,21 @@ async fn create(
     Ok((axum::http::StatusCode::CREATED, Json(result)))
 }
 
+#[utoipa::path(
+    put,
+    path = "/api/domains/{id}",
+    tag = "domains",
+    params(
+        ("id" = String, Path, description = "Domain ID")
+    ),
+    request_body = UpdateDomain,
+    responses(
+        (status = 200, description = "Domain updated", body = Domain),
+        (status = 404, description = "Domain not found"),
+        (status = 400, description = "Invalid input"),
+        (status = 500, description = "Internal server error")
+    )
+)]
 async fn update(
     State(state): State<AppState>,
     Path(id): Path<String>,
@@ -60,6 +113,19 @@ async fn update(
     Ok(Json(result))
 }
 
+#[utoipa::path(
+    delete,
+    path = "/api/domains/{id}",
+    tag = "domains",
+    params(
+        ("id" = String, Path, description = "Domain ID")
+    ),
+    responses(
+        (status = 204, description = "Domain deleted"),
+        (status = 404, description = "Domain not found"),
+        (status = 500, description = "Internal server error")
+    )
+)]
 async fn delete_one(
     State(state): State<AppState>,
     Path(id): Path<String>,

--- a/src/api/infra.rs
+++ b/src/api/infra.rs
@@ -5,7 +5,7 @@ use axum::{
 };
 use serde::Deserialize;
 
-use crate::models::{CreateInfra, PaginationParams, UpdateInfra};
+use crate::models::{CreateInfra, PaginationParams, UpdateInfra, InfraWithRelations, Infra};
 use crate::service::infra;
 use crate::{AppState, Result};
 
@@ -24,6 +24,21 @@ pub fn routes() -> Router<AppState> {
         .route("/{id}", get(get_one).put(update).delete(delete_one))
 }
 
+#[utoipa::path(
+    get,
+    path = "/api/infra",
+    tag = "infra",
+    params(
+        ("page" = Option<u32>, Query, description = "Page number"),
+        ("per_page" = Option<u32>, Query, description = "Items per page (max 100)"),
+        ("search" = Option<String>, Query, description = "Search query"),
+        ("type" = Option<String>, Query, description = "Filter by infrastructure type"),
+    ),
+    responses(
+        (status = 200, description = "List of infrastructure", body = inline(crate::models::PaginatedResponse<InfraWithRelations>)),
+        (status = 500, description = "Internal server error")
+    )
+)]
 async fn list(
     State(state): State<AppState>,
     Query(filters): Query<InfraFilters>,
@@ -37,6 +52,19 @@ async fn list(
     Ok(Json(result))
 }
 
+#[utoipa::path(
+    get,
+    path = "/api/infra/{id}",
+    tag = "infra",
+    params(
+        ("id" = String, Path, description = "Infrastructure ID")
+    ),
+    responses(
+        (status = 200, description = "Infrastructure found", body = InfraWithRelations),
+        (status = 404, description = "Infrastructure not found"),
+        (status = 500, description = "Internal server error")
+    )
+)]
 async fn get_one(
     State(state): State<AppState>,
     Path(id): Path<String>,
@@ -45,6 +73,17 @@ async fn get_one(
     Ok(Json(result))
 }
 
+#[utoipa::path(
+    post,
+    path = "/api/infra",
+    tag = "infra",
+    request_body = CreateInfra,
+    responses(
+        (status = 201, description = "Infrastructure created", body = Infra),
+        (status = 400, description = "Invalid input"),
+        (status = 500, description = "Internal server error")
+    )
+)]
 async fn create(
     State(state): State<AppState>,
     Json(input): Json<CreateInfra>,
@@ -53,6 +92,21 @@ async fn create(
     Ok((axum::http::StatusCode::CREATED, Json(result)))
 }
 
+#[utoipa::path(
+    put,
+    path = "/api/infra/{id}",
+    tag = "infra",
+    params(
+        ("id" = String, Path, description = "Infrastructure ID")
+    ),
+    request_body = UpdateInfra,
+    responses(
+        (status = 200, description = "Infrastructure updated", body = Infra),
+        (status = 404, description = "Infrastructure not found"),
+        (status = 400, description = "Invalid input"),
+        (status = 500, description = "Internal server error")
+    )
+)]
 async fn update(
     State(state): State<AppState>,
     Path(id): Path<String>,
@@ -62,6 +116,19 @@ async fn update(
     Ok(Json(result))
 }
 
+#[utoipa::path(
+    delete,
+    path = "/api/infra/{id}",
+    tag = "infra",
+    params(
+        ("id" = String, Path, description = "Infrastructure ID")
+    ),
+    responses(
+        (status = 204, description = "Infrastructure deleted"),
+        (status = 404, description = "Infrastructure not found"),
+        (status = 500, description = "Internal server error")
+    )
+)]
 async fn delete_one(
     State(state): State<AppState>,
     Path(id): Path<String>,

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -6,17 +6,17 @@ use axum::{Form, Json, Router};
 
 use crate::AppState;
 
-mod applications;
-mod dashboard;
-mod domains;
-mod healthchecks;
-mod infra;
-mod notes;
-mod people;
-mod search;
-mod services;
-mod shares;
-mod stacks;
+pub mod applications;
+pub mod dashboard;
+pub mod domains;
+pub mod healthchecks;
+pub mod infra;
+pub mod notes;
+pub mod people;
+pub mod search;
+pub mod services;
+pub mod shares;
+pub mod stacks;
 
 pub fn api_routes(state: AppState) -> Router<AppState> {
     Router::new()
@@ -36,10 +36,26 @@ pub fn api_routes(state: AppState) -> Router<AppState> {
         .with_state(state)
 }
 
+#[utoipa::path(
+    get,
+    path = "/api/health",
+    tag = "health",
+    responses(
+        (status = 200, description = "Service is healthy", body = String)
+    )
+)]
 async fn healthcheck() -> &'static str {
     "ok"
 }
 
+#[utoipa::path(
+    get,
+    path = "/api/version",
+    tag = "health",
+    responses(
+        (status = 200, description = "API version information", body = serde_json::Value)
+    )
+)]
 async fn version() -> Json<serde_json::Value> {
     Json(serde_json::json!({
         "version": env!("CARGO_PKG_VERSION")

--- a/src/api/notes.rs
+++ b/src/api/notes.rs
@@ -5,7 +5,7 @@ use axum::{
 };
 use serde::Deserialize;
 
-use crate::models::{CreateNote, PaginationParams, UpdateNote};
+use crate::models::{CreateNote, PaginationParams, UpdateNote, Note};
 use crate::service::note;
 use crate::{AppState, Result};
 
@@ -23,6 +23,22 @@ struct ListParams {
     pagination: PaginationParams,
 }
 
+#[utoipa::path(
+    get,
+    path = "/api/notes",
+    tag = "notes",
+    params(
+        ("entity_type" = String, Query, description = "Entity type (application, service, etc)"),
+        ("entity_id" = String, Query, description = "Entity ID"),
+        ("page" = Option<u32>, Query, description = "Page number"),
+        ("per_page" = Option<u32>, Query, description = "Items per page (max 100)"),
+        ("search" = Option<String>, Query, description = "Search query"),
+    ),
+    responses(
+        (status = 200, description = "List of notes", body = inline(crate::models::PaginatedResponse<Note>)),
+        (status = 500, description = "Internal server error")
+    )
+)]
 async fn list(
     State(state): State<AppState>,
     Query(params): Query<ListParams>,
@@ -37,6 +53,19 @@ async fn list(
     Ok(Json(result))
 }
 
+#[utoipa::path(
+    get,
+    path = "/api/notes/{id}",
+    tag = "notes",
+    params(
+        ("id" = String, Path, description = "Note ID")
+    ),
+    responses(
+        (status = 200, description = "Note found", body = Note),
+        (status = 404, description = "Note not found"),
+        (status = 500, description = "Internal server error")
+    )
+)]
 async fn get_one(
     State(state): State<AppState>,
     Path(id): Path<String>,
@@ -45,6 +74,17 @@ async fn get_one(
     Ok(Json(result))
 }
 
+#[utoipa::path(
+    post,
+    path = "/api/notes",
+    tag = "notes",
+    request_body = CreateNote,
+    responses(
+        (status = 201, description = "Note created", body = Note),
+        (status = 400, description = "Invalid input"),
+        (status = 500, description = "Internal server error")
+    )
+)]
 async fn create(
     State(state): State<AppState>,
     Json(input): Json<CreateNote>,
@@ -53,6 +93,21 @@ async fn create(
     Ok((axum::http::StatusCode::CREATED, Json(result)))
 }
 
+#[utoipa::path(
+    put,
+    path = "/api/notes/{id}",
+    tag = "notes",
+    params(
+        ("id" = String, Path, description = "Note ID")
+    ),
+    request_body = UpdateNote,
+    responses(
+        (status = 200, description = "Note updated", body = Note),
+        (status = 404, description = "Note not found"),
+        (status = 400, description = "Invalid input"),
+        (status = 500, description = "Internal server error")
+    )
+)]
 async fn update(
     State(state): State<AppState>,
     Path(id): Path<String>,
@@ -62,6 +117,19 @@ async fn update(
     Ok(Json(result))
 }
 
+#[utoipa::path(
+    delete,
+    path = "/api/notes/{id}",
+    tag = "notes",
+    params(
+        ("id" = String, Path, description = "Note ID")
+    ),
+    responses(
+        (status = 204, description = "Note deleted"),
+        (status = 404, description = "Note not found"),
+        (status = 500, description = "Internal server error")
+    )
+)]
 async fn delete_one(
     State(state): State<AppState>,
     Path(id): Path<String>,

--- a/src/api/people.rs
+++ b/src/api/people.rs
@@ -5,7 +5,7 @@ use axum::{
 };
 use serde::Deserialize;
 
-use crate::models::{CreatePerson, PaginationParams, UpdatePerson};
+use crate::models::{CreatePerson, PaginationParams, UpdatePerson, PersonWithRelations, Person};
 use crate::service::person;
 use crate::{AppState, Result};
 
@@ -23,6 +23,21 @@ pub fn routes() -> Router<AppState> {
         .route("/{id}", get(get_one).put(update).delete(delete_one))
 }
 
+#[utoipa::path(
+    get,
+    path = "/api/people",
+    tag = "people",
+    params(
+        ("page" = Option<u32>, Query, description = "Page number"),
+        ("per_page" = Option<u32>, Query, description = "Items per page (max 100)"),
+        ("search" = Option<String>, Query, description = "Search query"),
+        ("is_active" = Option<bool>, Query, description = "Filter by active status"),
+    ),
+    responses(
+        (status = 200, description = "List of people", body = inline(crate::models::PaginatedResponse<PersonWithRelations>)),
+        (status = 500, description = "Internal server error")
+    )
+)]
 async fn list(
     State(state): State<AppState>,
     Query(filters): Query<PersonFilters>,
@@ -36,6 +51,19 @@ async fn list(
     Ok(Json(result))
 }
 
+#[utoipa::path(
+    get,
+    path = "/api/people/{id}",
+    tag = "people",
+    params(
+        ("id" = String, Path, description = "Person ID")
+    ),
+    responses(
+        (status = 200, description = "Person found", body = PersonWithRelations),
+        (status = 404, description = "Person not found"),
+        (status = 500, description = "Internal server error")
+    )
+)]
 async fn get_one(
     State(state): State<AppState>,
     Path(id): Path<String>,
@@ -44,6 +72,17 @@ async fn get_one(
     Ok(Json(result))
 }
 
+#[utoipa::path(
+    post,
+    path = "/api/people",
+    tag = "people",
+    request_body = CreatePerson,
+    responses(
+        (status = 201, description = "Person created", body = Person),
+        (status = 400, description = "Invalid input"),
+        (status = 500, description = "Internal server error")
+    )
+)]
 async fn create(
     State(state): State<AppState>,
     Json(input): Json<CreatePerson>,
@@ -52,6 +91,21 @@ async fn create(
     Ok((axum::http::StatusCode::CREATED, Json(result)))
 }
 
+#[utoipa::path(
+    put,
+    path = "/api/people/{id}",
+    tag = "people",
+    params(
+        ("id" = String, Path, description = "Person ID")
+    ),
+    request_body = UpdatePerson,
+    responses(
+        (status = 200, description = "Person updated", body = Person),
+        (status = 404, description = "Person not found"),
+        (status = 400, description = "Invalid input"),
+        (status = 500, description = "Internal server error")
+    )
+)]
 async fn update(
     State(state): State<AppState>,
     Path(id): Path<String>,
@@ -61,6 +115,19 @@ async fn update(
     Ok(Json(result))
 }
 
+#[utoipa::path(
+    delete,
+    path = "/api/people/{id}",
+    tag = "people",
+    params(
+        ("id" = String, Path, description = "Person ID")
+    ),
+    responses(
+        (status = 204, description = "Person deleted"),
+        (status = 404, description = "Person not found"),
+        (status = 500, description = "Internal server error")
+    )
+)]
 async fn delete_one(
     State(state): State<AppState>,
     Path(id): Path<String>,

--- a/src/api/search.rs
+++ b/src/api/search.rs
@@ -1,7 +1,7 @@
 use axum::{Json, Router, extract::State, routing::get};
 use serde::Deserialize;
 
-use crate::service::search;
+use crate::service::search::{self, SearchResults};
 use crate::{AppState, Result};
 
 pub fn routes() -> Router<AppState> {
@@ -13,6 +13,18 @@ struct SearchQuery {
     q: String,
 }
 
+#[utoipa::path(
+    get,
+    path = "/api/search",
+    tag = "search",
+    params(
+        ("q" = String, Query, description = "Search query")
+    ),
+    responses(
+        (status = 200, description = "Search results", body = SearchResults),
+        (status = 500, description = "Internal server error")
+    )
+)]
 async fn global_search(
     State(state): State<AppState>,
     axum::extract::Query(query): axum::extract::Query<SearchQuery>,

--- a/src/api/stacks.rs
+++ b/src/api/stacks.rs
@@ -4,7 +4,7 @@ use axum::{
     routing::get,
 };
 
-use crate::models::{CreateStack, PaginationParams, UpdateStack};
+use crate::models::{CreateStack, PaginationParams, UpdateStack, StackWithRelations, Stack};
 use crate::service::stack;
 use crate::{AppState, Result};
 
@@ -14,6 +14,20 @@ pub fn routes() -> Router<AppState> {
         .route("/{id}", get(get_one).put(update).delete(delete_one))
 }
 
+#[utoipa::path(
+    get,
+    path = "/api/stacks",
+    tag = "stacks",
+    params(
+        ("page" = Option<u32>, Query, description = "Page number"),
+        ("per_page" = Option<u32>, Query, description = "Items per page (max 100)"),
+        ("search" = Option<String>, Query, description = "Search query"),
+    ),
+    responses(
+        (status = 200, description = "List of stacks", body = inline(crate::models::PaginatedResponse<Stack>)),
+        (status = 500, description = "Internal server error")
+    )
+)]
 async fn list(
     State(state): State<AppState>,
     Query(params): Query<PaginationParams>,
@@ -22,6 +36,19 @@ async fn list(
     Ok(Json(result))
 }
 
+#[utoipa::path(
+    get,
+    path = "/api/stacks/{id}",
+    tag = "stacks",
+    params(
+        ("id" = String, Path, description = "Stack ID")
+    ),
+    responses(
+        (status = 200, description = "Stack found", body = StackWithRelations),
+        (status = 404, description = "Stack not found"),
+        (status = 500, description = "Internal server error")
+    )
+)]
 async fn get_one(
     State(state): State<AppState>,
     Path(id): Path<String>,
@@ -30,6 +57,17 @@ async fn get_one(
     Ok(Json(result))
 }
 
+#[utoipa::path(
+    post,
+    path = "/api/stacks",
+    tag = "stacks",
+    request_body = CreateStack,
+    responses(
+        (status = 201, description = "Stack created", body = Stack),
+        (status = 400, description = "Invalid input"),
+        (status = 500, description = "Internal server error")
+    )
+)]
 async fn create(
     State(state): State<AppState>,
     Json(input): Json<CreateStack>,
@@ -38,6 +76,21 @@ async fn create(
     Ok((axum::http::StatusCode::CREATED, Json(result)))
 }
 
+#[utoipa::path(
+    put,
+    path = "/api/stacks/{id}",
+    tag = "stacks",
+    params(
+        ("id" = String, Path, description = "Stack ID")
+    ),
+    request_body = UpdateStack,
+    responses(
+        (status = 200, description = "Stack updated", body = Stack),
+        (status = 404, description = "Stack not found"),
+        (status = 400, description = "Invalid input"),
+        (status = 500, description = "Internal server error")
+    )
+)]
 async fn update(
     State(state): State<AppState>,
     Path(id): Path<String>,
@@ -47,6 +100,19 @@ async fn update(
     Ok(Json(result))
 }
 
+#[utoipa::path(
+    delete,
+    path = "/api/stacks/{id}",
+    tag = "stacks",
+    params(
+        ("id" = String, Path, description = "Stack ID")
+    ),
+    responses(
+        (status = 204, description = "Stack deleted"),
+        (status = 404, description = "Stack not found"),
+        (status = 500, description = "Internal server error")
+    )
+)]
 async fn delete_one(
     State(state): State<AppState>,
     Path(id): Path<String>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,11 +10,13 @@ mod config;
 mod error;
 pub mod kuma;
 pub mod models;
+mod openapi;
 mod routes;
 mod service;
 
 pub use config::Config;
 pub use error::Error;
+pub use openapi::ApiDoc;
 pub use routes::router;
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/src/models/application.rs
+++ b/src/models/application.rs
@@ -1,8 +1,9 @@
 use serde::{Deserialize, Serialize};
 use sqlx::FromRow;
+use utoipa::ToSchema;
 
 /// Application entity - the central entity in the system
-#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow, ToSchema)]
 pub struct Application {
     pub id: String,
     pub name: String,
@@ -18,7 +19,7 @@ pub struct Application {
 }
 
 /// DTO for creating a new application
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct CreateApplication {
     pub name: String,
     pub description: Option<String>,
@@ -32,7 +33,7 @@ pub struct CreateApplication {
 }
 
 /// DTO for updating an application
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct UpdateApplication {
     pub name: Option<String>,
     pub description: Option<String>,
@@ -52,7 +53,7 @@ fn default_status() -> String {
 }
 
 /// Application with all related entities
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct ApplicationWithRelations {
     #[serde(flatten)]
     pub application: Application,

--- a/src/models/domain.rs
+++ b/src/models/domain.rs
@@ -1,8 +1,9 @@
 use serde::{Deserialize, Serialize};
 use sqlx::FromRow;
+use utoipa::ToSchema;
 
 /// Domain entity - DNS records
-#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow, ToSchema)]
 pub struct Domain {
     pub id: String,
     pub fqdn: String,
@@ -18,7 +19,7 @@ pub struct Domain {
 }
 
 /// DTO for creating a new domain
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct CreateDomain {
     pub fqdn: String,
     pub registrar: Option<String>,
@@ -30,7 +31,7 @@ pub struct CreateDomain {
 }
 
 /// DTO for updating a domain
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct UpdateDomain {
     pub fqdn: Option<String>,
     pub registrar: Option<String>,
@@ -42,7 +43,7 @@ pub struct UpdateDomain {
 }
 
 /// Domain relation for application detail view
-#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow, ToSchema)]
 pub struct DomainRelation {
     pub id: String,
     pub fqdn: String,
@@ -54,12 +55,12 @@ pub struct DomainRelation {
 }
 
 /// DTO for linking a domain to an application
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct LinkDomain {
     pub notes: Option<String>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub enum DomainTarget {
     #[serde(rename = "application")]
     Application { id: String, name: String },
@@ -67,13 +68,13 @@ pub enum DomainTarget {
     Service { id: String, name: String },
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow, ToSchema)]
 pub struct TargetName {
     pub name: String,
 }
 
 /// Domain with related applications
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct DomainWithRelations {
     #[serde(flatten)]
     pub domain: Domain,
@@ -83,7 +84,7 @@ pub struct DomainWithRelations {
 }
 
 /// Application relation for domain detail view
-#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow, ToSchema)]
 pub struct ApplicationDomainRelation {
     pub id: String,
     pub name: String,

--- a/src/models/healthcheck.rs
+++ b/src/models/healthcheck.rs
@@ -1,9 +1,10 @@
 use serde::{Deserialize, Serialize};
 use sqlx::FromRow;
 use std::collections::HashMap;
+use utoipa::ToSchema;
 
 /// Healthcheck entity - HTTP checks for monitoring endpoints
-#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow, ToSchema)]
 pub struct Healthcheck {
     pub id: String,
     pub name: String,
@@ -33,7 +34,7 @@ pub struct Healthcheck {
 }
 
 /// DTO for creating a new healthcheck
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct CreateHealthcheck {
     pub name: String,
     pub application_id: Option<String>,
@@ -69,7 +70,7 @@ pub struct CreateHealthcheck {
 }
 
 /// DTO for updating a healthcheck
-#[derive(Debug, Deserialize, Default)]
+#[derive(Debug, Deserialize, Default, ToSchema)]
 pub struct UpdateHealthcheck {
     pub name: Option<String>,
     pub application_id: Option<String>,
@@ -131,7 +132,7 @@ fn default_request_body_encoding() -> String {
 }
 
 /// Healthcheck with resolved relations
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct HealthcheckWithRelations {
     #[serde(flatten)]
     pub healthcheck: Healthcheck,
@@ -142,7 +143,7 @@ pub struct HealthcheckWithRelations {
 }
 
 /// Lightweight healthcheck relation for embedding in Application/Service detail views
-#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow, ToSchema)]
 pub struct HealthcheckRelation {
     pub id: String,
     pub name: String,
@@ -155,7 +156,7 @@ pub struct HealthcheckRelation {
 }
 
 /// Result of executing a healthcheck
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct HealthcheckExecuteResult {
     pub healthcheck_id: String,
     pub url: String,
@@ -168,7 +169,7 @@ pub struct HealthcheckExecuteResult {
 }
 
 /// Kuma monitor export format
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct KumaMonitor {
     pub name: String,
     pub url: String,

--- a/src/models/infra.rs
+++ b/src/models/infra.rs
@@ -1,8 +1,9 @@
 use serde::{Deserialize, Serialize};
 use sqlx::FromRow;
+use utoipa::ToSchema;
 
 /// Infra entity - infrastructure like nomad clusters, servers, k8s clusters, etc.
-#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow, ToSchema)]
 pub struct Infra {
     pub id: String,
     pub name: String,
@@ -16,7 +17,7 @@ pub struct Infra {
 }
 
 /// DTO for creating a new infra
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct CreateInfra {
     pub name: String,
     pub description: Option<String>,
@@ -25,7 +26,7 @@ pub struct CreateInfra {
 }
 
 /// DTO for updating an infra
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct UpdateInfra {
     pub name: Option<String>,
     pub description: Option<String>,
@@ -34,7 +35,7 @@ pub struct UpdateInfra {
 }
 
 /// Infra relation for embedding in Application/Service detail views
-#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow, ToSchema)]
 pub struct InfraRelation {
     pub id: String,
     pub name: String,
@@ -45,13 +46,13 @@ pub struct InfraRelation {
 }
 
 /// DTO for linking infra to an application or service
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct LinkInfra {
     pub notes: Option<String>,
 }
 
 /// Infra with related entities
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct InfraWithRelations {
     #[serde(flatten)]
     pub infra: Infra,
@@ -60,7 +61,7 @@ pub struct InfraWithRelations {
 }
 
 /// Application relation for infra detail view
-#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow, ToSchema)]
 pub struct ApplicationInfraRelation {
     pub id: String,
     pub name: String,
@@ -69,7 +70,7 @@ pub struct ApplicationInfraRelation {
 }
 
 /// Service relation for infra detail view
-#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow, ToSchema)]
 pub struct ServiceInfraRelation {
     pub id: String,
     pub name: String,

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -21,9 +21,10 @@ pub use stack::*;
 pub use uptime::*;
 
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
 /// Common pagination parameters
-#[derive(Debug, Deserialize, Default)]
+#[derive(Debug, Deserialize, Default, ToSchema)]
 pub struct PaginationParams {
     pub page: Option<u32>,
     pub per_page: Option<u32>,
@@ -42,7 +43,7 @@ impl PaginationParams {
 }
 
 /// Paginated response wrapper
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct PaginatedResponse<T> {
     pub data: Vec<T>,
     pub total: i64,

--- a/src/models/network_share.rs
+++ b/src/models/network_share.rs
@@ -1,8 +1,9 @@
 use serde::{Deserialize, Serialize};
 use sqlx::FromRow;
+use utoipa::ToSchema;
 
 /// NetworkShare entity - SMB/NFS shares
-#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow, ToSchema)]
 pub struct NetworkShare {
     pub id: String,
     pub name: String,
@@ -18,7 +19,7 @@ pub struct NetworkShare {
 }
 
 /// DTO for creating a new network share
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct CreateNetworkShare {
     pub name: String,
     pub path: String,
@@ -32,7 +33,7 @@ pub struct CreateNetworkShare {
 }
 
 /// DTO for updating a network share
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct UpdateNetworkShare {
     pub name: Option<String>,
     pub path: Option<String>,
@@ -52,7 +53,7 @@ fn default_status() -> String {
 }
 
 /// NetworkShare relation for application detail view
-#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow, ToSchema)]
 pub struct NetworkShareRelation {
     pub id: String,
     pub name: String,
@@ -67,7 +68,7 @@ pub struct NetworkShareRelation {
 }
 
 /// DTO for linking a network share to an application
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct LinkNetworkShare {
     pub usage: Option<String>,
     pub mount_point: Option<String>,
@@ -76,7 +77,7 @@ pub struct LinkNetworkShare {
 }
 
 /// NetworkShare with related applications
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct NetworkShareWithRelations {
     #[serde(flatten)]
     pub network_share: NetworkShare,
@@ -84,7 +85,7 @@ pub struct NetworkShareWithRelations {
 }
 
 /// Application relation for network share detail view
-#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow, ToSchema)]
 pub struct ApplicationNetworkShareRelation {
     pub id: String,
     pub name: String,

--- a/src/models/note.rs
+++ b/src/models/note.rs
@@ -1,8 +1,9 @@
 use serde::{Deserialize, Serialize};
 use sqlx::FromRow;
+use utoipa::ToSchema;
 
 /// Note entity - documentation links, changelog, issues
-#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow, ToSchema)]
 pub struct Note {
     pub id: String,
     pub entity_type: String,
@@ -18,7 +19,7 @@ pub struct Note {
 }
 
 /// DTO for creating a new note
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct CreateNote {
     pub entity_type: String,
     pub entity_id: String,
@@ -32,7 +33,7 @@ pub struct CreateNote {
 }
 
 /// DTO for updating a note
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct UpdateNote {
     pub title: Option<String>,
     pub content: Option<String>,

--- a/src/models/person.rs
+++ b/src/models/person.rs
@@ -1,8 +1,9 @@
 use serde::{Deserialize, Serialize};
 use sqlx::FromRow;
+use utoipa::ToSchema;
 
 /// Person entity - developers, maintainers, support contacts
-#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow, ToSchema)]
 pub struct Person {
     pub id: String,
     pub name: String,
@@ -18,7 +19,7 @@ pub struct Person {
 }
 
 /// DTO for creating a new person
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct CreatePerson {
     pub name: String,
     pub email: Option<String>,
@@ -31,7 +32,7 @@ pub struct CreatePerson {
 }
 
 /// DTO for updating a person
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct UpdatePerson {
     pub name: Option<String>,
     pub email: Option<String>,
@@ -47,7 +48,7 @@ fn default_active() -> bool {
 }
 
 /// Person relation for application detail view
-#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow, ToSchema)]
 pub struct PersonRelation {
     pub id: String,
     pub name: String,
@@ -61,7 +62,7 @@ pub struct PersonRelation {
 }
 
 /// DTO for linking a person to an application
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct LinkPerson {
     #[serde(default = "default_contribution")]
     pub contribution_type: String,
@@ -75,7 +76,7 @@ fn default_contribution() -> String {
 }
 
 /// Person with related applications
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct PersonWithRelations {
     #[serde(flatten)]
     pub person: Person,
@@ -83,7 +84,7 @@ pub struct PersonWithRelations {
 }
 
 /// Application relation for person detail view
-#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow, ToSchema)]
 pub struct ApplicationPersonRelation {
     pub id: String,
     pub name: String,

--- a/src/models/service.rs
+++ b/src/models/service.rs
@@ -1,8 +1,9 @@
 use serde::{Deserialize, Serialize};
 use sqlx::FromRow;
+use utoipa::ToSchema;
 
 /// Service entity - shared services like elasticsearch, load balancers, etc.
-#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow, ToSchema)]
 pub struct Service {
     pub id: String,
     pub name: String,
@@ -17,7 +18,7 @@ pub struct Service {
 }
 
 /// DTO for creating a new service
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct CreateService {
     pub name: String,
     pub description: Option<String>,
@@ -30,7 +31,7 @@ pub struct CreateService {
 }
 
 /// DTO for updating a service
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct UpdateService {
     pub name: Option<String>,
     pub description: Option<String>,
@@ -49,7 +50,7 @@ fn default_status() -> String {
 }
 
 /// Service relation for embedding in Application/Infra detail views
-#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow, ToSchema)]
 pub struct ServiceRelation {
     pub id: String,
     pub name: String,
@@ -59,13 +60,13 @@ pub struct ServiceRelation {
 }
 
 /// DTO for linking a service to an application
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct LinkService {
     pub notes: Option<String>,
 }
 
 /// Service with related entities
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct ServiceWithRelations {
     #[serde(flatten)]
     pub service: Service,
@@ -75,7 +76,7 @@ pub struct ServiceWithRelations {
 }
 
 /// Application relation for service detail view
-#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow, ToSchema)]
 pub struct ApplicationServiceRelation {
     pub id: String,
     pub name: String,

--- a/src/models/stack.rs
+++ b/src/models/stack.rs
@@ -1,8 +1,9 @@
 use serde::{Deserialize, Serialize};
 use sqlx::FromRow;
+use utoipa::ToSchema;
 
 /// Stack entity - programming languages, frameworks, technologies
-#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow, ToSchema)]
 pub struct Stack {
     pub id: String,
     pub name: String,
@@ -12,28 +13,28 @@ pub struct Stack {
 }
 
 /// DTO for creating a new stack
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct CreateStack {
     pub name: String,
     pub notes: Option<String>,
 }
 
 /// DTO for updating a stack
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 pub struct UpdateStack {
     pub name: Option<String>,
     pub notes: Option<String>,
 }
 
 /// Stack relation for application detail view
-#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow, ToSchema)]
 pub struct StackRelation {
     pub id: String,
     pub name: String,
 }
 
 /// Stack with related applications
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct StackWithRelations {
     #[serde(flatten)]
     pub stack: Stack,
@@ -41,7 +42,7 @@ pub struct StackWithRelations {
 }
 
 /// Application relation for stack detail view
-#[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow, ToSchema)]
 pub struct ApplicationStackRelation {
     pub id: String,
     pub name: String,

--- a/src/models/uptime.rs
+++ b/src/models/uptime.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
 /// How many seconds of heartbeat history to keep in memory (1 hour).
 pub const HEARTBEAT_WINDOW_SECS: i64 = 3600;
@@ -8,7 +9,7 @@ pub const HEARTBEAT_WINDOW_SECS: i64 = 3600;
 /// A single heartbeat record from Kuma.
 ///
 /// Status codes: 1 = up, 0 = down, 2 = pending, 3 = maintenance.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct HeartbeatEntry {
     pub status: i32,
     pub time: String,
@@ -17,7 +18,7 @@ pub struct HeartbeatEntry {
 }
 
 /// In-memory uptime state for one Kuma monitor, capped to the last hour.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, ToSchema)]
 pub struct MonitorUptime {
     pub kuma_id: i32,
     pub heartbeats: Vec<HeartbeatEntry>,
@@ -27,7 +28,7 @@ pub struct MonitorUptime {
 ///
 /// `Snapshot` is sent once when a client connects (full current state).
 /// `Update` is sent whenever a new heartbeat arrives for one monitor.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, ToSchema)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum UptimeEvent {
     Snapshot {

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -1,0 +1,248 @@
+use utoipa::openapi::security::{HttpAuthScheme, HttpBuilder, SecurityScheme};
+use utoipa::{Modify, OpenApi};
+
+#[derive(OpenApi)]
+#[openapi(
+    info(
+        title = "Auto API",
+        version = "1.0.1",
+        description = "Digital assets management system API\n\n**Authentication:** This API is protected by HTTP Basic Authentication at the reverse proxy level (Caddy). All endpoints require authentication credentials which are validated by the reverse proxy before requests reach this application.",
+    ),
+    paths(
+        // Health endpoints
+        crate::api::healthcheck,
+        crate::api::version,
+        
+        // Applications
+        crate::api::applications::list,
+        crate::api::applications::get_one,
+        crate::api::applications::create,
+        crate::api::applications::update,
+        crate::api::applications::delete_one,
+        crate::api::applications::link_infra,
+        crate::api::applications::unlink_infra,
+        crate::api::applications::link_service,
+        crate::api::applications::unlink_service,
+        crate::api::applications::link_domain,
+        crate::api::applications::unlink_domain,
+        crate::api::applications::link_person,
+        crate::api::applications::unlink_person,
+        crate::api::applications::link_share,
+        crate::api::applications::unlink_share,
+        crate::api::applications::link_stack,
+        crate::api::applications::unlink_stack,
+        
+        // Services
+        crate::api::services::list,
+        crate::api::services::get_one,
+        crate::api::services::create,
+        crate::api::services::update,
+        crate::api::services::delete_one,
+        crate::api::services::link_infra,
+        crate::api::services::unlink_infra,
+        
+        // Infrastructure
+        crate::api::infra::list,
+        crate::api::infra::get_one,
+        crate::api::infra::create,
+        crate::api::infra::update,
+        crate::api::infra::delete_one,
+        
+        // Domains
+        crate::api::domains::list,
+        crate::api::domains::get_one,
+        crate::api::domains::create,
+        crate::api::domains::update,
+        crate::api::domains::delete_one,
+        
+        // People
+        crate::api::people::list,
+        crate::api::people::get_one,
+        crate::api::people::create,
+        crate::api::people::update,
+        crate::api::people::delete_one,
+        
+        // Network shares
+        crate::api::shares::list,
+        crate::api::shares::get_one,
+        crate::api::shares::create,
+        crate::api::shares::update,
+        crate::api::shares::delete_one,
+        
+        // Notes
+        crate::api::notes::list,
+        crate::api::notes::get_one,
+        crate::api::notes::create,
+        crate::api::notes::update,
+        crate::api::notes::delete_one,
+        
+        // Stacks
+        crate::api::stacks::list,
+        crate::api::stacks::get_one,
+        crate::api::stacks::create,
+        crate::api::stacks::update,
+        crate::api::stacks::delete_one,
+        
+        // Healthchecks
+        crate::api::healthchecks::list,
+        crate::api::healthchecks::get_one,
+        crate::api::healthchecks::create,
+        crate::api::healthchecks::update,
+        crate::api::healthchecks::delete_one,
+        crate::api::healthchecks::execute,
+        crate::api::healthchecks::export_kuma,
+        crate::api::healthchecks::sync_kuma_one,
+        crate::api::healthchecks::sync_kuma_all,
+        
+        // Dashboard
+        crate::api::dashboard::stats,
+        
+        // Search
+        crate::api::search::global_search,
+    ),
+    components(
+        schemas(
+            // Common models
+            crate::models::PaginationParams,
+            crate::models::PaginatedResponse<crate::models::Application>,
+            crate::models::PaginatedResponse<crate::models::Service>,
+            crate::models::PaginatedResponse<crate::models::Infra>,
+            crate::models::PaginatedResponse<crate::models::Domain>,
+            crate::models::PaginatedResponse<crate::models::Person>,
+            crate::models::PaginatedResponse<crate::models::NetworkShare>,
+            crate::models::PaginatedResponse<crate::models::Note>,
+            crate::models::PaginatedResponse<crate::models::Stack>,
+            crate::models::PaginatedResponse<crate::models::Healthcheck>,
+            
+            // Applications
+            crate::models::Application,
+            crate::models::CreateApplication,
+            crate::models::UpdateApplication,
+            crate::models::ApplicationWithRelations,
+            
+            // Services
+            crate::models::Service,
+            crate::models::CreateService,
+            crate::models::UpdateService,
+            crate::models::ServiceRelation,
+            crate::models::LinkService,
+            crate::models::ServiceWithRelations,
+            crate::models::ApplicationServiceRelation,
+            
+            // Infrastructure
+            crate::models::Infra,
+            crate::models::CreateInfra,
+            crate::models::UpdateInfra,
+            crate::models::InfraRelation,
+            crate::models::LinkInfra,
+            crate::models::InfraWithRelations,
+            crate::models::ApplicationInfraRelation,
+            crate::models::ServiceInfraRelation,
+            
+            // Domains
+            crate::models::Domain,
+            crate::models::CreateDomain,
+            crate::models::UpdateDomain,
+            crate::models::DomainRelation,
+            crate::models::LinkDomain,
+            crate::models::DomainTarget,
+            crate::models::TargetName,
+            crate::models::DomainWithRelations,
+            crate::models::ApplicationDomainRelation,
+            
+            // People
+            crate::models::Person,
+            crate::models::CreatePerson,
+            crate::models::UpdatePerson,
+            crate::models::PersonRelation,
+            crate::models::LinkPerson,
+            crate::models::PersonWithRelations,
+            crate::models::ApplicationPersonRelation,
+            
+            // Network shares
+            crate::models::NetworkShare,
+            crate::models::CreateNetworkShare,
+            crate::models::UpdateNetworkShare,
+            crate::models::NetworkShareRelation,
+            crate::models::LinkNetworkShare,
+            crate::models::NetworkShareWithRelations,
+            crate::models::ApplicationNetworkShareRelation,
+            
+            // Notes
+            crate::models::Note,
+            crate::models::CreateNote,
+            crate::models::UpdateNote,
+            
+            // Stacks
+            crate::models::Stack,
+            crate::models::CreateStack,
+            crate::models::UpdateStack,
+            crate::models::StackRelation,
+            crate::models::StackWithRelations,
+            crate::models::ApplicationStackRelation,
+            
+            // Healthchecks
+            crate::models::Healthcheck,
+            crate::models::CreateHealthcheck,
+            crate::models::UpdateHealthcheck,
+            crate::models::HealthcheckWithRelations,
+            crate::models::HealthcheckRelation,
+            crate::models::HealthcheckExecuteResult,
+            crate::models::KumaMonitor,
+            
+            // Uptime
+            crate::models::HeartbeatEntry,
+            crate::models::MonitorUptime,
+            crate::models::UptimeEvent,
+            
+            // Service layer
+            crate::service::dashboard::DashboardStats,
+            crate::service::dashboard::EntityStats,
+            crate::service::dashboard::ExpiringDomain,
+            crate::service::search::SearchResults,
+            crate::service::search::SearchResult,
+        )
+    ),
+    tags(
+        (name = "health", description = "Health check endpoints"),
+        (name = "applications", description = "Application management"),
+        (name = "services", description = "Service management"),
+        (name = "infra", description = "Infrastructure management"),
+        (name = "domains", description = "Domain management"),
+        (name = "people", description = "People management"),
+        (name = "shares", description = "Network shares management"),
+        (name = "notes", description = "Notes management"),
+        (name = "stacks", description = "Technology stacks management"),
+        (name = "healthchecks", description = "Health checks management"),
+        (name = "dashboard", description = "Dashboard statistics"),
+        (name = "search", description = "Global search"),
+    ),
+    modifiers(&SecurityAddon)
+)]
+pub struct ApiDoc;
+
+struct SecurityAddon;
+
+impl Modify for SecurityAddon {
+    fn modify(&self, openapi: &mut utoipa::openapi::OpenApi) {
+        if let Some(components) = openapi.components.as_mut() {
+            components.add_security_scheme(
+                "http_basic",
+                SecurityScheme::Http(
+                    HttpBuilder::new()
+                        .scheme(HttpAuthScheme::Basic)
+                        .description(Some(
+                            "HTTP Basic Authentication handled by Caddy reverse proxy",
+                        ))
+                        .build(),
+                ),
+            );
+        }
+
+        // Apply security globally to all operations
+        openapi.security = Some(vec![utoipa::openapi::security::SecurityRequirement::new(
+            "http_basic",
+            Vec::<String>::new(),
+        )]);
+    }
+}

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -7,11 +7,14 @@ use axum::{
 };
 use rust_embed::Embed;
 use tower_http::{compression::CompressionLayer, trace::TraceLayer};
+use utoipa::OpenApi;
+use utoipa_swagger_ui::SwaggerUi;
 
-use crate::{AppState, api};
+use crate::{ApiDoc, AppState, api};
 
 pub fn router(state: AppState) -> Router {
     axum::Router::new()
+        .merge(SwaggerUi::new("/api/docs").url("/api/openapi.json", ApiDoc::openapi()))
         .nest("/api", api::api_routes(state.clone()))
         .route("/", get(serve_frontend))
         .route("/{*path}", get(serve_frontend))

--- a/src/service/dashboard.rs
+++ b/src/service/dashboard.rs
@@ -1,10 +1,11 @@
 use serde::Serialize;
 use sqlx::SqlitePool;
 use tracing::info;
+use utoipa::ToSchema;
 
 use crate::Result;
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct DashboardStats {
     pub applications: EntityStats,
     pub services: EntityStats,
@@ -16,13 +17,13 @@ pub struct DashboardStats {
     pub expiring_domains: Vec<ExpiringDomain>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct EntityStats {
     pub total: i64,
     pub active: i64,
 }
 
-#[derive(Debug, Serialize, sqlx::FromRow)]
+#[derive(Debug, Serialize, sqlx::FromRow, ToSchema)]
 pub struct ExpiringDomain {
     pub id: String,
     pub fqdn: String,

--- a/src/service/search.rs
+++ b/src/service/search.rs
@@ -1,10 +1,11 @@
 use serde::Serialize;
 use sqlx::SqlitePool;
 use tokio::try_join;
+use utoipa::ToSchema;
 
 use crate::Result;
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 pub struct SearchResults {
     pub applications: Vec<SearchResult>,
     pub services: Vec<SearchResult>,
@@ -15,7 +16,7 @@ pub struct SearchResults {
     pub stacks: Vec<SearchResult>,
 }
 
-#[derive(Debug, Serialize, sqlx::FromRow)]
+#[derive(Debug, Serialize, sqlx::FromRow, ToSchema)]
 pub struct SearchResult {
     pub id: String,
     pub name: String,


### PR DESCRIPTION
Add OpenAPI-spec compliant API documentation.

The OpanAPI json can be retrieved from /api/openapi.json,
and a HTML interactive documentation platform is hosted at /api/docs.

- closes #58
