### PR TITLE
Auto-expand request body editor

### DIFF
--- a/frontend/src/components/forms/HealthcheckForm.vue
+++ b/frontend/src/components/forms/HealthcheckForm.vue
@@ -197,6 +197,16 @@ function addHeader() {
 function removeHeader(index: number) {
   headersArray.value.splice(index, 1);
 }
+
+// Auto-expand request body section when switching to a method that supports it
+watch(
+  () => form.value.method,
+  (method) => {
+    if (['POST', 'PUT', 'PATCH'].includes(method)) {
+      showRequestBody.value = true;
+    }
+  }
+);
 </script>
 
 <template>


### PR DESCRIPTION
## Summary
- Auto-expands the request body collapsible section when switching to POST/PUT/PATCH method in the healthcheck form, making the editor more discoverable

Closes #56