### PR TITLE
Kuma notifications

### DIFF
--- a/frontend/src/components/forms/HealthcheckForm.vue
+++ b/frontend/src/components/forms/HealthcheckForm.vue
@@ -49,6 +49,7 @@ const form = ref<CreateHealthcheck>({
   timeout_seconds: 1,
   interval: 60,
   is_enabled: true,
+  notifications: false,
   notes: '',
   retry: 0,
   retry_interval: 20,
@@ -109,6 +110,7 @@ watch(
         timeout_seconds: hc.timeout_seconds,
         interval: hc.interval,
         is_enabled: hc.is_enabled,
+        notifications: hc.notifications,
         notes: hc.notes || '',
         retry: hc.retry,
         retry_interval: hc.retry_interval,
@@ -161,7 +163,7 @@ function handleSubmit() {
     application_id: form.value.application_id || undefined,
     service_id: form.value.service_id || undefined,
     kuma_id: form.value.kuma_id || undefined,
-    expected_body: form.value.expected_body || undefined,
+    expected_body: form.value.expected_body || '',
     notes: form.value.notes || undefined,
     request_body: form.value.request_body || undefined,
     http_auth_user: form.value.http_auth_user || undefined,
@@ -562,6 +564,18 @@ watch(
             class="toggle toggle-primary"
           />
           <span>{{ form.is_enabled ? 'Enabled' : 'Disabled' }}</span>
+        </label>
+      </fieldset>
+
+      <fieldset class="fieldset md:col-span-2">
+        <legend class="fieldset-legend">Notifications</legend>
+        <label class="label cursor-pointer justify-start gap-4">
+          <input
+            type="checkbox"
+            v-model="form.notifications"
+            class="toggle toggle-primary"
+          />
+          <span>{{ form.notifications ? 'Enabled' : 'Disabled' }}</span>
         </label>
       </fieldset>
     </div>

--- a/frontend/src/composables/useUptime.ts
+++ b/frontend/src/composables/useUptime.ts
@@ -20,7 +20,17 @@ type UptimeEvent =
 const monitors = ref<Map<number, MonitorData>>(new Map());
 let eventSource: EventSource | null = null;
 let consumerCount = 0;
+let closeTimer: ReturnType<typeof setTimeout> | null = null;
 const HEARTBEAT_WINDOW_SIZE = 120;
+// Grace period before tearing down the stream once the last consumer unmounts.
+// Bridges route navigations (old component unmounts before the new one mounts)
+// so the long-lived connection survives instead of reconnecting every page hop.
+const CLOSE_GRACE_MS = 5000;
+
+// Registered once for the app lifetime, not per-connection.
+window.addEventListener('beforeunload', () => {
+  if (eventSource) eventSource.close();
+});
 
 function openConnection() {
   if (eventSource) return;
@@ -63,10 +73,6 @@ function openConnection() {
     // EventSource handles reconnect automatically.
     // On reconnect, the backend sends a fresh snapshot.
   };
-
-  window.addEventListener('beforeunload', () => {
-    if (eventSource) eventSource.close();
-  });
 }
 
 function closeConnection() {
@@ -77,15 +83,22 @@ function closeConnection() {
 }
 
 export function useUptime() {
-  consumerCount++;
-  if (consumerCount === 1) {
-    openConnection();
+  // A new consumer arrived — cancel any pending teardown so navigation
+  // between uptime views reuses the existing connection.
+  if (closeTimer !== null) {
+    clearTimeout(closeTimer);
+    closeTimer = null;
   }
+  consumerCount++;
+  openConnection();
 
   onUnmounted(() => {
     consumerCount--;
-    if (consumerCount === 0) {
-      closeConnection();
+    if (consumerCount === 0 && closeTimer === null) {
+      closeTimer = setTimeout(() => {
+        closeTimer = null;
+        if (consumerCount === 0) closeConnection();
+      }, CLOSE_GRACE_MS);
     }
   });
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -614,6 +614,7 @@ export interface Healthcheck {
   request_body: string | null;
   http_auth_user: string | null;
   http_auth_pass: string | null;
+  notifications: boolean;
   kuma_dirty: boolean;
   created_at: string;
   updated_at: string;
@@ -642,6 +643,7 @@ export interface CreateHealthcheck {
   request_body?: string;
   http_auth_user?: string;
   http_auth_pass?: string;
+  notifications?: boolean;
 }
 
 export interface UpdateHealthcheck {
@@ -666,6 +668,7 @@ export interface UpdateHealthcheck {
   request_body?: string;
   http_auth_user?: string;
   http_auth_pass?: string;
+  notifications?: boolean;
 }
 
 export interface HealthcheckWithRelations extends Healthcheck {
@@ -683,6 +686,7 @@ export interface HealthcheckRelation {
   path: string;
   expected_status: number;
   is_enabled: boolean;
+  notifications: boolean;
   kuma_id: number | null;
   kuma_dirty: boolean;
 }

--- a/frontend/src/views/applications/ApplicationDetail.vue
+++ b/frontend/src/views/applications/ApplicationDetail.vue
@@ -62,7 +62,7 @@ import MarkdownRenderer from '@/components/common/MarkdownRenderer.vue';
 import StackBadge from '@/components/common/StackBadge.vue';
 import { infraTypes } from '@/values';
 import type { ImageRef } from '@/types';
-import { Pin, ExternalLink, Plus, Edit, Link2Off } from 'lucide-vue-next';
+import { Pin, ExternalLink, Plus, Edit, Link2Off, Bell } from 'lucide-vue-next';
 import HealthcheckForm from '@/components/forms/HealthcheckForm.vue';
 import HealthPlot from '@/components/common/HealthPlot.vue';
 import ImageRefBadge from '@/components/common/ImageRefBadge.vue';
@@ -1057,7 +1057,18 @@ onUnmounted(() => document.removeEventListener('keydown', handleGlobalKeydown));
                       class="cursor-pointer hover:bg-base-300"
                       @click="router.push(`/healthchecks/${h.id}`)"
                     >
-                      <td>{{ h.name }}</td>
+                      <td>
+                        <span class="flex items-center gap-1.5">
+                          {{ h.name }}
+                          <span
+                            v-if="h.notifications"
+                            title="Notifications enabled"
+                            class="inline-flex"
+                          >
+                            <Bell class="w-3.5 h-3.5 text-primary shrink-0" />
+                          </span>
+                        </span>
+                      </td>
                       <td class="font-mono text-xs truncate max-w-50">
                         {{ h.protocol }}://{{ h.domain_fqdn }}{{ h.path }}
                       </td>

--- a/frontend/src/views/dashboard/DashboardView.vue
+++ b/frontend/src/views/dashboard/DashboardView.vue
@@ -6,6 +6,7 @@ import type { ComponentPublicInstance } from 'vue';
 import { useUptime } from '@/composables/useUptime';
 import LoadingSpinner from '@/components/common/LoadingSpinner.vue';
 import HealthPlot from '@/components/common/HealthPlot.vue';
+import { Bell } from 'lucide-vue-next';
 
 const stats = ref<DashboardStats | null>(null);
 const healthchecks = ref<Healthcheck[]>([]);
@@ -339,6 +340,13 @@ onMounted(() => {
                     toTitleCase(item.healthcheck.name)
                   }}</span>
                 </router-link>
+                <span
+                  v-if="item.healthcheck.notifications"
+                  title="Notifications enabled"
+                  class="inline-flex shrink-0"
+                >
+                  <Bell class="w-3.5 h-3.5 text-primary" />
+                </span>
               </div>
 
               <!-- Sparkline -->

--- a/frontend/src/views/healthchecks/HealthcheckDetail.vue
+++ b/frontend/src/views/healthchecks/HealthcheckDetail.vue
@@ -10,6 +10,7 @@ import EntityDetail from '@/components/common/EntityDetail.vue';
 import StatusBadge from '@/components/common/StatusBadge.vue';
 import HealthPlot from '@/components/common/HealthPlot.vue';
 import HealthcheckForm from '@/components/forms/HealthcheckForm.vue';
+import { Bell } from 'lucide-vue-next';
 
 const syncLoading = ref(false);
 
@@ -98,13 +99,22 @@ async function goToKuma() {
     :delete-fn="healthchecksApi.delete"
   >
     <template #status="{ entity }">
-      <StatusBadge
-        :status="
-          (entity as HealthcheckWithRelations).is_enabled
-            ? 'active'
-            : 'inactive'
-        "
-      />
+      <span class="flex items-center gap-2">
+        <StatusBadge
+          :status="
+            (entity as HealthcheckWithRelations).is_enabled
+              ? 'active'
+              : 'inactive'
+          "
+        />
+        <span
+          v-if="(entity as HealthcheckWithRelations).notifications"
+          title="Notifications enabled"
+          class="inline-flex"
+        >
+          <Bell class="w-4 h-4 text-primary" />
+        </span>
+      </span>
     </template>
 
     <template #details="{ entity }">

--- a/frontend/src/views/healthchecks/HealthcheckList.vue
+++ b/frontend/src/views/healthchecks/HealthcheckList.vue
@@ -8,6 +8,7 @@ import StatusBadge from '@/components/common/StatusBadge.vue';
 import HealthcheckForm from '@/components/forms/HealthcheckForm.vue';
 import ImportWizard from '@/components/import/ImportWizard.vue';
 import HealthStats from '@/components/common/HealthStats.vue';
+import { Bell } from 'lucide-vue-next';
 
 const syncLoading = ref(false);
 
@@ -99,6 +100,9 @@ function handlePanelChange(isOpen: boolean, widthRem: number) {
       <td class="font-medium">
         <span class="flex items-center gap-1.5">
           {{ item.name }}
+          <span v-if="item.notifications" title="Notifications enabled" class="inline-flex">
+            <Bell class="w-3.5 h-3.5 text-primary shrink-0" />
+          </span>
           <span
             v-if="item.kuma_dirty"
             class="inline-block w-2 h-2 rounded-full bg-warning shrink-0"

--- a/frontend/src/views/services/ServiceDetail.vue
+++ b/frontend/src/views/services/ServiceDetail.vue
@@ -21,7 +21,7 @@ import ServiceForm from '@/components/forms/ServiceForm.vue';
 import InfraForm from '@/components/forms/InfraForm.vue';
 import LinkInfraForm from '@/components/forms/LinkInfraForm.vue';
 import { infraTypes } from '@/values';
-import { Plus, Edit, Link2Off, Package } from 'lucide-vue-next';
+import { Plus, Edit, Link2Off, Package, Bell } from 'lucide-vue-next';
 import HealthcheckForm from '@/components/forms/HealthcheckForm.vue';
 import HealthPlot from '@/components/common/HealthPlot.vue';
 import ImageRefBadge from '@/components/common/ImageRefBadge.vue';
@@ -425,7 +425,16 @@ onUnmounted(() => document.removeEventListener('keydown', handleGlobalKeydown));
                   @click="router.push(`/healthchecks/${h.id}`)"
                 >
                   <div class="flex-1 min-w-0">
-                    <span class="font-medium">{{ h.name }}</span>
+                    <span class="font-medium inline-flex items-center gap-1.5">
+                      {{ h.name }}
+                      <span
+                        v-if="h.notifications"
+                        title="Notifications enabled"
+                        class="inline-flex"
+                      >
+                        <Bell class="w-3.5 h-3.5 text-primary shrink-0" />
+                      </span>
+                    </span>
                     <div class="text-xs text-base-content/70 font-mono">
                       {{ h.protocol }}://{{ h.domain_fqdn }}{{ h.path }}
                     </div>

--- a/migrations/20260527120002_healthcheck_notifications.sql
+++ b/migrations/20260527120002_healthcheck_notifications.sql
@@ -1,0 +1,2 @@
+-- Track whether a healthcheck has notifications enabled or not
+ALTER TABLE healthcheck ADD COLUMN notifications INTEGER NOT NULL DEFAULT 0;

--- a/src/api/healthchecks.rs
+++ b/src/api/healthchecks.rs
@@ -280,7 +280,7 @@ async fn uptime_stream(
     let snapshot = {
         let read = state.uptime_state.read().await;
         UptimeEvent::Snapshot {
-            monitors: read.clone(),
+            monitors: read.uptimes.clone(),
         }
     };
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,6 +12,7 @@ pub struct Config {
     pub kuma_url: Url,
     pub kuma_username: String,
     pub kuma_password: String,
+    pub kuma_notification_name: Option<String>,
     pub outline_url: Option<Url>,
     pub outline_api_key: Option<String>,
     /// How many days before an infra's domain-resolved IPs are considered stale
@@ -55,6 +56,7 @@ impl Config {
             kuma_url: Url::parse(&var("KUMA_URL")).expect("KUMA_URL should be a valid URL"),
             kuma_username: var("KUMA_USERNAME"),
             kuma_password: var("KUMA_PASSWORD"),
+            kuma_notification_name: std::env::var("KUMA_NOTIFICATION_NAME").ok(),
             outline_url,
             outline_api_key,
             infra_ip_refresh_days,

--- a/src/kuma.rs
+++ b/src/kuma.rs
@@ -20,6 +20,7 @@ use rust_socketio::{
     Payload,
     asynchronous::{Client as SocketClient, ClientBuilder},
 };
+use serde::Deserialize;
 use serde_json::{Value, json};
 use tokio::sync::{RwLock, broadcast, mpsc, watch};
 use tracing::{debug, error, info, trace, warn};
@@ -35,8 +36,23 @@ use crate::{
 
 // ── Public type aliases ────────────────────────────────────────────
 
-pub type UptimeState = Arc<RwLock<HashMap<i32, MonitorUptime>>>;
+pub struct UptimeStateInner {
+    pub uptimes: HashMap<i32, MonitorUptime>,
+    pub notification_handlers: HashMap<i32, String>,
+}
+
+pub type UptimeState = Arc<RwLock<UptimeStateInner>>;
 pub type UptimeTx = broadcast::Sender<UptimeEvent>;
+
+impl UptimeStateInner {
+    pub async fn find_notification_handler(&self, name: &str) -> Option<i32> {
+        self.notification_handlers
+            .iter()
+            .find(|(_, s)| s.to_lowercase() == name.to_lowercase())
+            .map(|(k, _)| k)
+            .copied()
+    }
+}
 
 // ── KumaClient (unchanged) ────────────────────────────────────────
 
@@ -188,7 +204,10 @@ fn extract_monitor_id(response: &Value, event: &str) -> Result<i32> {
 
 // ── Monitor JSON builder ────────────────────────────────────────────
 
-fn build_monitor_json(hc_with_relations: &HealthcheckWithRelations) -> Value {
+fn build_monitor_json(
+    hc_with_relations: &HealthcheckWithRelations,
+    notification_handler_id: Option<i32>,
+) -> Value {
     let url = hc_with_relations.url();
     let hc = &hc_with_relations.healthcheck;
 
@@ -198,8 +217,14 @@ fn build_monitor_json(hc_with_relations: &HealthcheckWithRelations) -> Value {
         _ => "json",
     };
 
+    let monitor_type = if hc.expected_body.is_some() {
+        "keyword"
+    } else {
+        "http"
+    };
+
     let mut monitor = json!({
-        "type": "http",
+        "type": monitor_type,
         "name": hc.name,
         "interval": hc.interval,
         "active": hc.is_enabled,
@@ -210,7 +235,7 @@ fn build_monitor_json(hc_with_relations: &HealthcheckWithRelations) -> Value {
         "method": hc.method,
         "httpBodyEncoding": encoding,
         "accepted_statuscodes": [hc.expected_status.to_string()],
-        "conditions": "[]"
+        "conditions": "[]",
     });
 
     let obj = monitor.as_object_mut().unwrap();
@@ -223,6 +248,15 @@ fn build_monitor_json(hc_with_relations: &HealthcheckWithRelations) -> Value {
     }
     if let Some(ref headers) = hc.headers {
         obj.insert("headers".into(), json!(headers));
+    }
+    if let Some(ref keyword) = hc.expected_body {
+        obj.insert("keyword".into(), json!(keyword));
+    }
+    if let Some(notification_handler_id) = notification_handler_id {
+        obj.insert(
+            "notificationIDList".into(),
+            json!({notification_handler_id.to_string(): hc.notifications}),
+        );
     }
 
     // Authentication
@@ -256,7 +290,8 @@ pub async fn sync_healthcheck_to_kuma(state: AppState, id: &str) -> Result<()> {
     let mut success = false;
 
     if hc.healthcheck.is_enabled {
-        let mut monitor = build_monitor_json(&hc);
+        let notification_handler_id = state.get_kuma_notification_handler_id().await;
+        let mut monitor = build_monitor_json(&hc, notification_handler_id);
         if let Some(kuma_id) = kuma_id {
             monitor
                 .as_object_mut()
@@ -308,6 +343,8 @@ pub async fn sync_healthchecks_to_kuma(state: AppState) -> Result<()> {
 
     let healthchecks = service::healthcheck::get_all_with_relations(&state.pool).await?;
 
+    let notification_handler_id = state.get_kuma_notification_handler_id().await;
+
     for hc in healthchecks {
         let name = hc.healthcheck.name.clone();
         let hc_id = hc.healthcheck.id.clone();
@@ -315,7 +352,7 @@ pub async fn sync_healthchecks_to_kuma(state: AppState) -> Result<()> {
         let mut success = false;
 
         if hc.healthcheck.is_enabled {
-            let mut monitor = build_monitor_json(&hc);
+            let mut monitor = build_monitor_json(&hc, notification_handler_id);
             if let Some(kuma_id) = kuma_id {
                 monitor
                     .as_object_mut()
@@ -457,8 +494,9 @@ async fn connect_and_poll(
     let tx_for_hb_list = uptime_tx.clone();
     let state_for_hb = uptime_state.clone();
     let tx_for_hb = uptime_tx.clone();
+    let state_for_nf_list = uptime_state.clone();
 
-    let socket = ClientBuilder::new(config.kuma_url.as_str())
+    let mut client_builder = ClientBuilder::new(config.kuma_url.as_str())
         .on_any(move |event, _payload, _client| {
             let ready = ready_signal.clone();
             async move {
@@ -486,7 +524,21 @@ async fn connect_and_poll(
                 }
             }
             .boxed()
-        })
+        });
+
+    if config.kuma_notification_name.is_some() {
+        client_builder = client_builder.on("notificationList", move |payload: Payload, _client| {
+            let state = state_for_nf_list.clone();
+            async move {
+                if let Payload::Text(values) = payload {
+                    handle_notification_list(values, state).await;
+                }
+            }
+            .boxed()
+        });
+    }
+
+    let socket = client_builder
         .connect()
         .await
         .map_err(|e| Error::KumaError(format!("Poller connection failed: {e}")))?;
@@ -600,7 +652,7 @@ async fn handle_heartbeat_list(values: Vec<Value>, state: UptimeState, tx: Uptim
     let import_length = heartbeats.len();
 
     let mut write = state.write().await;
-    write.insert(
+    write.uptimes.insert(
         kuma_id,
         MonitorUptime {
             kuma_id,
@@ -612,7 +664,7 @@ async fn handle_heartbeat_list(values: Vec<Value>, state: UptimeState, tx: Uptim
     // Broadcast snapshot to all connected SSE clients
     let snapshot = {
         let read = state.read().await;
-        read.clone()
+        read.uptimes.clone()
     };
     let _ = tx.send(UptimeEvent::Snapshot { monitors: snapshot });
 
@@ -620,6 +672,36 @@ async fn handle_heartbeat_list(values: Vec<Value>, state: UptimeState, tx: Uptim
         "Kuma poller: received heartbeat list for id {} ({} heartbeats)",
         kuma_id, import_length
     );
+}
+
+#[derive(Deserialize, Debug)]
+struct NotificationHandler {
+    id: i32,
+    name: String,
+}
+
+async fn handle_notification_list(values: Vec<Value>, state: UptimeState) {
+    let data = match values.into_iter().next() {
+        Some(v) => v,
+        None => return,
+    };
+
+    let Some(notification_handlers): Option<Vec<NotificationHandler>> =
+        serde_json::from_value(data).ok()
+    else {
+        return;
+    };
+
+    let mut write = state.write().await;
+
+    for nfh in notification_handlers {
+        write
+            .notification_handlers
+            .entry(nfh.id)
+            .insert_entry(nfh.name);
+    }
+
+    info!("Kuma poller: received notification handler list");
 }
 
 /// Processes `heartbeat` — a single real-time heartbeat from Kuma.
@@ -643,7 +725,7 @@ async fn handle_heartbeat(values: Vec<Value>, state: UptimeState, tx: UptimeTx) 
 
     let is_new = {
         let mut write = state.write().await;
-        let monitor = write.entry(kuma_id).or_insert(MonitorUptime {
+        let monitor = write.uptimes.entry(kuma_id).or_insert(MonitorUptime {
             kuma_id,
             heartbeats: Vec::new(),
         });

--- a/src/kuma.rs
+++ b/src/kuma.rs
@@ -168,14 +168,16 @@ impl KumaClient {
         extract_monitor_id(&response, "add")
     }
 
-    async fn resume_monitor(&self, kuma_id: i32) -> Result<i32> {
-        let response = self.call("resumeMonitor", json!({"id": kuma_id})).await?;
-        extract_monitor_id(&response, "resumeMonitor")
+    async fn resume_monitor(&self, kuma_id: i32) -> Result<()> {
+        // Kuma's resumeMonitor handler takes the id as a bare scalar, not an object.
+        let response = self.call("resumeMonitor", json!(kuma_id)).await?;
+        check_ok(&response, "resumeMonitor")
     }
 
-    async fn pause_monitor(&self, kuma_id: i32) -> Result<i32> {
-        let response = self.call("pauseMonitor", json!({"id": kuma_id})).await?;
-        extract_monitor_id(&response, "pauseMonitor")
+    async fn pause_monitor(&self, kuma_id: i32) -> Result<()> {
+        // Kuma's pauseMonitor handler takes the id as a bare scalar, not an object.
+        let response = self.call("pauseMonitor", json!(kuma_id)).await?;
+        check_ok(&response, "pauseMonitor")
     }
 
     async fn disconnect(self) -> Result<()> {
@@ -185,6 +187,18 @@ impl KumaClient {
             .map_err(|e| Error::KumaError(format!("Disconnect failed: {e}")))?;
         Ok(())
     }
+}
+
+/// Validate an ack that only reports success (no monitorID), e.g. pauseMonitor/resumeMonitor.
+fn check_ok(response: &Value, event: &str) -> Result<()> {
+    if response.get("ok").and_then(|v| v.as_bool()) != Some(true) {
+        let msg = response
+            .get("msg")
+            .and_then(|v| v.as_str())
+            .unwrap_or("Unknown error");
+        return Err(Error::KumaError(format!("{event} failed: {msg}")));
+    }
+    Ok(())
 }
 
 fn extract_monitor_id(response: &Value, event: &str) -> Result<i32> {
@@ -217,11 +231,9 @@ fn build_monitor_json(
         _ => "json",
     };
 
-    let monitor_type = if hc.expected_body.is_some() {
-        "keyword"
-    } else {
-        "http"
-    };
+    // Treat an empty keyword as "no keyword" so cleared bodies revert to a plain http check.
+    let keyword = hc.expected_body.as_deref().filter(|s| !s.trim().is_empty());
+    let monitor_type = if keyword.is_some() { "keyword" } else { "http" };
 
     let mut monitor = json!({
         "type": monitor_type,
@@ -249,7 +261,7 @@ fn build_monitor_json(
     if let Some(ref headers) = hc.headers {
         obj.insert("headers".into(), json!(headers));
     }
-    if let Some(ref keyword) = hc.expected_body {
+    if let Some(keyword) = keyword {
         obj.insert("keyword".into(), json!(keyword));
     }
     if let Some(notification_handler_id) = notification_handler_id {
@@ -345,50 +357,75 @@ pub async fn sync_healthchecks_to_kuma(state: AppState) -> Result<()> {
 
     let notification_handler_id = state.get_kuma_notification_handler_id().await;
 
+    let mut failures = 0usize;
+
     for hc in healthchecks {
         let name = hc.healthcheck.name.clone();
         let hc_id = hc.healthcheck.id.clone();
         let kuma_id = hc.healthcheck.kuma_id;
-        let mut success = false;
 
-        if hc.healthcheck.is_enabled {
-            let mut monitor = build_monitor_json(&hc, notification_handler_id);
-            if let Some(kuma_id) = kuma_id {
-                monitor
-                    .as_object_mut()
-                    .unwrap()
-                    .insert("id".into(), json!(kuma_id));
-                debug!("Editing monitor '{name}' (kuma_id: {kuma_id})");
-                client.edit_monitor(monitor).await?;
-                client.resume_monitor(kuma_id).await?;
+        // Sync one healthcheck. A failure here must not abort the whole batch —
+        // otherwise one bad monitor blocks every later one from syncing.
+        let result: Result<bool> = async {
+            if hc.healthcheck.is_enabled {
+                let mut monitor = build_monitor_json(&hc, notification_handler_id);
+                if let Some(kuma_id) = kuma_id {
+                    monitor
+                        .as_object_mut()
+                        .unwrap()
+                        .insert("id".into(), json!(kuma_id));
+                    debug!("Editing monitor '{name}' (kuma_id: {kuma_id})");
+                    client.edit_monitor(monitor).await?;
+                    client.resume_monitor(kuma_id).await?;
+                } else {
+                    debug!("Adding monitor '{name}'");
+                    let new_id = client.add_monitor(monitor).await?;
+                    debug!("Created monitor '{name}' with kuma_id: {new_id}");
+                    service::healthcheck::update(
+                        &state.pool,
+                        &hc_id,
+                        UpdateHealthcheck {
+                            kuma_id: Some(new_id),
+                            ..Default::default()
+                        },
+                    )
+                    .await?;
+                    debug!("Updated Auto healthcheck's kuma_id");
+                }
+                Ok(true)
+            } else if let Some(kuma_id) = kuma_id {
+                client.pause_monitor(kuma_id).await?;
+                Ok(true)
             } else {
-                debug!("Adding monitor '{name}'");
-                let new_id = client.add_monitor(monitor).await?;
-                debug!("Created monitor '{name}' with kuma_id: {new_id}");
-                service::healthcheck::update(
-                    &state.pool,
-                    &hc_id,
-                    UpdateHealthcheck {
-                        kuma_id: Some(new_id),
-                        ..Default::default()
-                    },
-                )
-                .await?;
-                debug!("Updated Auto healthcheck's kuma_id");
+                Ok(false)
             }
-            success = true;
-        } else if let Some(kuma_id) = kuma_id {
-            client.pause_monitor(kuma_id).await?;
-            success = true;
         }
+        .await;
 
-        if success {
+        match result {
             // Clear dirty flag — this healthcheck is now in sync with Kuma
-            service::healthcheck::clear_kuma_dirty(&state.pool, &hc_id).await?;
+            Ok(true) => {
+                if let Err(e) = service::healthcheck::clear_kuma_dirty(&state.pool, &hc_id).await {
+                    warn!("Failed to clear kuma_dirty for '{name}': {e}");
+                    failures += 1;
+                }
+            }
+            Ok(false) => {}
+            Err(e) => {
+                warn!("Failed to sync healthcheck '{name}' to Kuma: {e}");
+                failures += 1;
+            }
         }
     }
 
     client.disconnect().await?;
+
+    if failures > 0 {
+        return Err(Error::KumaError(format!(
+            "{failures} healthcheck(s) failed to sync to Kuma"
+        )));
+    }
+
     debug!("Kuma sync complete");
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,8 @@ pub type Result<T> = std::result::Result<T, Error>;
 use kuma::{UptimeState, UptimeTx};
 use models::{DnsRecord, UptimeEvent};
 
+use crate::kuma::UptimeStateInner;
+
 /// Shared cache of live DNS lookups, keyed by FQDN.
 /// Holds the monotonic fill instant (for TTL), the RFC3339 wall-clock resolve time
 /// (for display), and the records, so [`service::dns`] can honor a short TTL.
@@ -77,7 +79,10 @@ impl AppState {
         let pool = SqlitePool::connect(&config.database_url).await?;
 
         let (uptime_tx, _) = broadcast::channel::<UptimeEvent>(64);
-        let uptime_state: UptimeState = Arc::new(RwLock::new(HashMap::new()));
+        let uptime_state: UptimeState = Arc::new(RwLock::new(UptimeStateInner {
+            uptimes: HashMap::new(),
+            notification_handlers: HashMap::new(),
+        }));
         let (kuma_refresh_tx, _) = watch::channel(());
 
         info!("Building DNS resolver from system config");
@@ -112,5 +117,17 @@ impl AppState {
         };
 
         Ok(state)
+    }
+
+    pub async fn get_kuma_notification_handler_id(&self) -> Option<i32> {
+        if let Some(n) = &self.config.kuma_notification_name {
+            self.uptime_state
+                .read()
+                .await
+                .find_notification_handler(n)
+                .await
+        } else {
+            None
+        }
     }
 }

--- a/src/models/healthcheck.rs
+++ b/src/models/healthcheck.rs
@@ -29,6 +29,7 @@ pub struct Healthcheck {
     pub http_auth_user: Option<String>,
     pub http_auth_pass: Option<String>,
     pub kuma_dirty: bool,
+    pub notifications: bool,
     pub created_at: String,
     pub updated_at: String,
     pub created_by: Option<String>,
@@ -68,6 +69,7 @@ pub struct CreateHealthcheck {
     pub request_body: Option<String>,
     pub http_auth_user: Option<String>,
     pub http_auth_pass: Option<String>,
+    pub notifications: bool,
 }
 
 /// DTO for updating a healthcheck
@@ -94,6 +96,7 @@ pub struct UpdateHealthcheck {
     pub request_body: Option<String>,
     pub http_auth_user: Option<String>,
     pub http_auth_pass: Option<String>,
+    pub notifications: Option<bool>,
 }
 
 fn default_protocol() -> String {
@@ -161,6 +164,7 @@ pub struct HealthcheckRelation {
     pub is_enabled: bool,
     pub kuma_id: Option<i32>,
     pub kuma_dirty: bool,
+    pub notifications: bool,
 }
 
 /// Result of executing a healthcheck

--- a/src/service/healthcheck.rs
+++ b/src/service/healthcheck.rs
@@ -82,7 +82,7 @@ pub async fn get(pool: &SqlitePool, id: &str) -> Result<Healthcheck> {
                expected_body, timeout_seconds, interval, is_enabled, notes,
                retry, retry_interval, request_body_encoding, request_body,
                http_auth_user, http_auth_pass, kuma_id, kuma_dirty,
-               created_at, updated_at, created_by, h.notifications
+               created_at, updated_at, created_by, notifications
         FROM healthcheck
         WHERE id = ?1
         "#,
@@ -101,7 +101,7 @@ pub async fn get_all(pool: &SqlitePool) -> Result<Vec<Healthcheck>> {
                expected_body, timeout_seconds, interval, is_enabled, notes,
                retry, retry_interval, request_body_encoding, request_body,
                http_auth_user, http_auth_pass, kuma_id, kuma_dirty,
-               created_at, updated_at, created_by, h.notifications
+               created_at, updated_at, created_by, notifications
         FROM healthcheck
         "#,
     )
@@ -228,7 +228,7 @@ pub async fn create(pool: &SqlitePool, input: CreateHealthcheck) -> Result<Healt
     .bind(&input.method)
     .bind(&input.headers)
     .bind(input.expected_status)
-    .bind(&input.expected_body)
+    .bind(input.expected_body.as_deref().filter(|s| !s.trim().is_empty()))
     .bind(input.timeout_seconds)
     .bind(input.interval)
     .bind(input.is_enabled)
@@ -286,7 +286,18 @@ pub async fn update(pool: &SqlitePool, id: &str, input: UpdateHealthcheck) -> Re
     let path = input.path.unwrap_or(existing.path);
     let method = input.method.unwrap_or(existing.method);
     let expected_status = input.expected_status.unwrap_or(existing.expected_status);
-    let expected_body = input.expected_body.or(existing.expected_body);
+    // Distinguish "field provided as empty" (explicit clear) from "field omitted" (keep existing).
+    // An empty string clears the keyword so the Kuma monitor reverts to a plain http check.
+    let expected_body = match input.expected_body {
+        Some(s) => {
+            if s.trim().is_empty() {
+                None
+            } else {
+                Some(s)
+            }
+        }
+        None => existing.expected_body,
+    };
     let timeout_seconds = input.timeout_seconds.unwrap_or(existing.timeout_seconds);
     let interval = input.interval.unwrap_or(existing.interval);
     let is_enabled = input.is_enabled.unwrap_or(existing.is_enabled);
@@ -587,7 +598,7 @@ pub async fn get_for_service(
 ) -> Result<Vec<HealthcheckRelation>> {
     sqlx::query_as::<_, HealthcheckRelation>(
         r#"
-        SELECT h.id, h.name, h.protocol, d.fqdn as domain_fqdn, h.notifictations,
+        SELECT h.id, h.name, h.protocol, d.fqdn as domain_fqdn, h.notifications,
                h.path, h.expected_status, h.is_enabled, h.kuma_id, h.kuma_dirty
         FROM healthcheck h
         JOIN domain d ON h.domain_id = d.id

--- a/src/service/healthcheck.rs
+++ b/src/service/healthcheck.rs
@@ -30,7 +30,7 @@ pub async fn list(
                h.expected_body, h.timeout_seconds, h.interval, h.is_enabled, h.notes,
                h.retry, h.retry_interval, h.request_body_encoding, h.request_body,
                h.http_auth_user, h.http_auth_pass, h.kuma_id, h.kuma_dirty,
-               h.created_at, h.updated_at, h.created_by
+               h.created_at, h.updated_at, h.created_by, h.notifications
         FROM healthcheck h
         WHERE (?1 IS NULL OR h.name LIKE ?1)
           AND (?2 IS NULL OR h.application_id = ?2)
@@ -82,7 +82,7 @@ pub async fn get(pool: &SqlitePool, id: &str) -> Result<Healthcheck> {
                expected_body, timeout_seconds, interval, is_enabled, notes,
                retry, retry_interval, request_body_encoding, request_body,
                http_auth_user, http_auth_pass, kuma_id, kuma_dirty,
-               created_at, updated_at, created_by
+               created_at, updated_at, created_by, h.notifications
         FROM healthcheck
         WHERE id = ?1
         "#,
@@ -101,7 +101,7 @@ pub async fn get_all(pool: &SqlitePool) -> Result<Vec<Healthcheck>> {
                expected_body, timeout_seconds, interval, is_enabled, notes,
                retry, retry_interval, request_body_encoding, request_body,
                http_auth_user, http_auth_pass, kuma_id, kuma_dirty,
-               created_at, updated_at, created_by
+               created_at, updated_at, created_by, h.notifications
         FROM healthcheck
         "#,
     )
@@ -213,8 +213,8 @@ pub async fn create(pool: &SqlitePool, input: CreateHealthcheck) -> Result<Healt
                                  protocol, path, method, headers, expected_status,
                                  expected_body, timeout_seconds, interval, is_enabled, notes,
                                  retry, retry_interval, request_body_encoding, request_body,
-                                 http_auth_user, http_auth_pass, kuma_dirty)
-        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, 1)
+                                 http_auth_user, http_auth_pass, notifications, kuma_dirty)
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23, 1)
         "#,
     )
     .bind(&id)
@@ -239,6 +239,7 @@ pub async fn create(pool: &SqlitePool, input: CreateHealthcheck) -> Result<Healt
     .bind(&input.request_body)
     .bind(&input.http_auth_user)
     .bind(&input.http_auth_pass)
+    .bind(input.notifications)
     .execute(pool)
     .await?;
 
@@ -299,6 +300,7 @@ pub async fn update(pool: &SqlitePool, id: &str, input: UpdateHealthcheck) -> Re
     let http_auth_user = input.http_auth_user.or(existing.http_auth_user);
     let http_auth_pass = input.http_auth_pass.or(existing.http_auth_pass);
     let kuma_id = input.kuma_id.or(existing.kuma_id);
+    let notifications = input.notifications.unwrap_or(existing.notifications);
 
     sqlx::query(
         r#"
@@ -308,7 +310,7 @@ pub async fn update(pool: &SqlitePool, id: &str, input: UpdateHealthcheck) -> Re
             expected_status = ?9, expected_body = ?10, timeout_seconds = ?11,
             is_enabled = ?12, notes = ?13, retry = ?14, retry_interval = ?15,
             request_body_encoding = ?16, request_body = ?17, interval = ?22,
-            http_auth_user = ?18, http_auth_pass = ?19, kuma_id = ?21,
+            http_auth_user = ?18, http_auth_pass = ?19, kuma_id = ?21, notifications = ?23,
             kuma_dirty = 1, updated_at = datetime('now')
         WHERE id = ?20
         "#,
@@ -335,6 +337,7 @@ pub async fn update(pool: &SqlitePool, id: &str, input: UpdateHealthcheck) -> Re
     .bind(id)
     .bind(kuma_id)
     .bind(interval)
+    .bind(notifications)
     .execute(pool)
     .await?;
 
@@ -507,7 +510,7 @@ pub async fn export_kuma(pool: &SqlitePool) -> Result<Vec<KumaMonitor>> {
                protocol, path, method, headers, expected_status,
                expected_body, timeout_seconds, interval, is_enabled, notes,
                retry, retry_interval, request_body_encoding, request_body,
-               http_auth_user, http_auth_pass, kuma_id, kuma_dirty,
+               http_auth_user, http_auth_pass, kuma_id, kuma_dirty, notifications,
                created_at, updated_at, created_by
         FROM healthcheck
         WHERE is_enabled = 1
@@ -564,7 +567,7 @@ pub async fn get_for_application(
     sqlx::query_as::<_, HealthcheckRelation>(
         r#"
         SELECT h.id, h.name, h.protocol, h.kuma_id, d.fqdn as domain_fqdn,
-               h.path, h.expected_status, h.is_enabled, h.kuma_dirty
+               h.path, h.expected_status, h.is_enabled, h.kuma_dirty, h.notifications
         FROM healthcheck h
         JOIN domain d ON h.domain_id = d.id
         WHERE h.application_id = ?1
@@ -584,7 +587,7 @@ pub async fn get_for_service(
 ) -> Result<Vec<HealthcheckRelation>> {
     sqlx::query_as::<_, HealthcheckRelation>(
         r#"
-        SELECT h.id, h.name, h.protocol, d.fqdn as domain_fqdn,
+        SELECT h.id, h.name, h.protocol, d.fqdn as domain_fqdn, h.notifictations,
                h.path, h.expected_status, h.is_enabled, h.kuma_id, h.kuma_dirty
         FROM healthcheck h
         JOIN domain d ON h.domain_id = d.id


### PR DESCRIPTION
- **feat(database): healthcheck notifications migration**
- **feat(backend): service layer for healthchecks with notifications**
- **feat(backend): handle notificationList from kuma and send along with updates**
- **feat(frontend): healthcheck notifications UI**
- **fix(frontend): keep websocket for longer between pages**
- **fix(backend): kuma monitors pause/resume logic**

- closes #115
